### PR TITLE
perf: refactor `reset` method to clear all collections

### DIFF
--- a/src/Store.ts
+++ b/src/Store.ts
@@ -65,8 +65,9 @@ export class Store<
   }
 
   reset(): void {
-    const schemaObjectTypes = resolveSchemaObjectTypes(this.schema)
-    this._collections = initializeCollections<TypesMap>(schemaObjectTypes)
+    for (const collection of this._collections.values()) {
+      collection.clear()
+    }
   }
 
   protected createDocument<Type extends keyof TypesMap>(

--- a/tests/reset.test.ts
+++ b/tests/reset.test.ts
@@ -1,0 +1,23 @@
+import { Store } from '../src'
+import { schema, TypesMap } from './fixtures'
+import { postFactory, userFactory } from './utils/factories'
+import { toCollection } from './utils'
+
+const store = new Store<TypesMap>({
+  schema,
+})
+
+afterEach(() => store.reset())
+
+it('should clear all collections at once', () => {
+  toCollection(() => store.create('User', userFactory()), 5)
+  toCollection(() => store.create('Post', postFactory()), 5)
+
+  expect(store.count('User')).toEqual(5)
+  expect(store.count('Post')).toEqual(5)
+
+  store.reset()
+
+  expect(store.count('User')).toEqual(0)
+  expect(store.count('Post')).toEqual(0)
+})


### PR DESCRIPTION
This PR refactors the reset method to clear all collections instead of re-initializing collection maps. This improves the performance by avoiding unnecessary traverse of the schema and garbage collection to free up the memory.