### PR TITLE
feat: add `delete` operation

### DIFF
--- a/src/DocumentCollection.ts
+++ b/src/DocumentCollection.ts
@@ -50,7 +50,6 @@ export class DocumentCollection<DocumentType> {
   }
 
   delete(document: Document<DocumentType>) {
-    const key = getDocumentKey(document)
-    return this.documents.delete(key)
+    return this.documents.delete(getDocumentKey(document))
   }
 }

--- a/src/DocumentCollection.ts
+++ b/src/DocumentCollection.ts
@@ -49,7 +49,8 @@ export class DocumentCollection<DocumentType> {
     return this.documents.clear()
   }
 
-  delete(id: string) {
-    return this.documents.delete(id)
+  delete(document: Document<DocumentType>) {
+    const key = getDocumentKey(document)
+    return this.documents.delete(key)
   }
 }

--- a/src/DocumentCollection.ts
+++ b/src/DocumentCollection.ts
@@ -48,4 +48,8 @@ export class DocumentCollection<DocumentType> {
   clear() {
     return this.documents.clear()
   }
+
+  delete(id: string) {
+    return this.documents.delete(id)
+  }
 }

--- a/src/Operations.ts
+++ b/src/Operations.ts
@@ -75,13 +75,12 @@ export abstract class Operations<TypesMap extends Record<string, any>> {
 
   delete<Type extends TypesMap[keyof TypesMap]>(document: Type) {
     if (!isDocument(document)) {
-      throw new Error(
-        'Cannot delete the document because it is not a valid document.',
-      )
+      throw new Error('Input document is not a valid document.')
     }
 
     const type = getDocumentType(document)
+    const key = getDocumentKey(document)
 
-    return this.collection(type).delete(document as TypesMap[string])
+    return this.collection(type).delete(key)
   }
 }

--- a/src/Operations.ts
+++ b/src/Operations.ts
@@ -75,12 +75,13 @@ export abstract class Operations<TypesMap extends Record<string, any>> {
 
   delete<Type extends TypesMap[keyof TypesMap]>(document: Type) {
     if (!isDocument(document)) {
-      throw new Error('Input document is not a valid document.')
+      throw new Error(
+        'Cannot delete the document because it is not a valid document.',
+      )
     }
 
     const type = getDocumentType(document)
-    const key = getDocumentKey(document)
 
-    return this.collection(type).delete(key)
+    return this.collection(type).delete(document as TypesMap[string])
   }
 }

--- a/src/Operations.ts
+++ b/src/Operations.ts
@@ -72,4 +72,15 @@ export abstract class Operations<TypesMap extends Record<string, any>> {
   clear(...types: Array<keyof TypesMap>) {
     types.forEach((type) => this.collection(type).clear())
   }
+
+  delete<Type extends TypesMap[keyof TypesMap]>(document: Type) {
+    if (!isDocument(document)) {
+      throw new Error('Input document is not a valid document.')
+    }
+
+    const type = getDocumentType(document)
+    const key = getDocumentKey(document)
+
+    return this.collection(type).delete(key)
+  }
 }

--- a/src/Operations.ts
+++ b/src/Operations.ts
@@ -76,7 +76,7 @@ export abstract class Operations<TypesMap extends Record<string, any>> {
   delete<Type extends TypesMap[keyof TypesMap]>(document: Type) {
     if (!isDocument(document)) {
       throw new Error(
-        'Cannot delete the document because it is not a valid document.',
+        'Cannot delete the input because it is not a valid document.',
       )
     }
 

--- a/tests/delete.test.ts
+++ b/tests/delete.test.ts
@@ -1,0 +1,51 @@
+import { Store } from '../src'
+import { schema, TypesMap } from './fixtures'
+import { postFactory, userFactory } from './utils/factories'
+import { toCollection } from './utils'
+
+const store = new Store<TypesMap>({
+  schema,
+})
+
+afterEach(() => store.reset())
+
+it('should delete single documents in a collection', () => {
+  toCollection(() => store.create('User', userFactory()), 5)
+  const user = store.findFirstOrThrow('User')
+  expect(store.count('User')).toEqual(5)
+
+  store.delete(user)
+
+  expect(store.count('User')).toEqual(4)
+  expect(
+    store.find('User', (data) => {
+      return data.username.startsWith(user.username)
+    }),
+  ).toEqual([])
+})
+
+it('should not affect other collections', () => {
+  toCollection(() => store.create('User', userFactory()), 5)
+  toCollection(() => store.create('Post', postFactory()), 5)
+  const user = store.findFirstOrThrow('User')
+
+  expect(store.count('User')).toEqual(5)
+  expect(store.count('Post')).toEqual(5)
+
+  store.delete(user)
+
+  expect(store.count('User')).toEqual(4)
+  expect(store.count('Post')).toEqual(5)
+  expect(
+    store.find('User', (data) => {
+      return data.username.startsWith(user.username)
+    }),
+  ).toEqual([])
+})
+
+it('should throw error if input document is not valid', () => {
+  const data = userFactory()
+  expect(() => store.delete(data)).toThrowError(
+    'Input document is not a valid document.',
+  )
+})

--- a/tests/delete.test.ts
+++ b/tests/delete.test.ts
@@ -46,6 +46,6 @@ it('should not affect other collections', () => {
 it('should throw error if input document is not valid', () => {
   const data = userFactory()
   expect(() => store.delete(data)).toThrowError(
-    'Input document is not a valid document.',
+    'Cannot delete the document because it is not a valid document.',
   )
 })

--- a/tests/delete.test.ts
+++ b/tests/delete.test.ts
@@ -46,6 +46,6 @@ it('should not affect other collections', () => {
 it('should throw error if input document is not valid', () => {
   const data = userFactory()
   expect(() => store.delete(data)).toThrowError(
-    'Cannot delete the document because it is not a valid document.',
+    'Cannot delete the input because it is not a valid document.',
   )
 })


### PR DESCRIPTION
This PR contains the logic for single document delete functionality. By receiving the original document and using the `delete(key)` on the store map.