### PR TITLE
chore(tests): update schema

### DIFF
--- a/tests/clear.test.ts
+++ b/tests/clear.test.ts
@@ -1,6 +1,6 @@
 import { Store } from '../src'
 import { schema, TypesMap } from './fixtures'
-import { postFactory, userFactory, userProfileFactory } from './utils/factories'
+import { postFactory, userFactory, profileFactory } from './utils/factories'
 import { toCollection } from './utils'
 
 const store = new Store<TypesMap>({
@@ -18,8 +18,10 @@ it('should delete all documents in a collection', () => {
 })
 
 it('should not affect other collections', () => {
-  toCollection(() => store.add('User', userFactory()), 5)
-  toCollection(() => store.add('Post', postFactory()), 5)
+  toCollection(
+    () => store.add('Post', postFactory({ author: userFactory() })),
+    5,
+  )
 
   expect(store.count('User')).toEqual(5)
   expect(store.count('Post')).toEqual(5)
@@ -31,38 +33,28 @@ it('should not affect other collections', () => {
 })
 
 it('should not delete relative documents', () => {
-  store.add(
-    'User',
-    userFactory({
-      posts: toCollection(postFactory, 3),
-    }),
-  )
+  store.add('User', userFactory({ profile: profileFactory() }))
 
   expect(store.count('User')).toEqual(1)
-  expect(store.count('Post')).toEqual(3)
+  expect(store.count('Profile')).toEqual(1)
 
   store.clear('User')
 
   expect(store.count('User')).toEqual(0)
-  expect(store.count('Post')).toEqual(3)
+  expect(store.count('Profile')).toEqual(1)
 })
 
 it('can clear multiple collections', () => {
-  store.add(
-    'User',
-    userFactory({
-      profile: userProfileFactory(),
-      posts: toCollection(postFactory, 3),
-    }),
-  )
+  store.add('Post', postFactory())
+  store.add('User', userFactory())
 
-  expect(store.count('User')).toEqual(1)
-  expect(store.count('Post')).toEqual(3)
-  expect(store.count('UserProfile')).toEqual(1)
+  expect(store.count('Post')).toEqual(1)
+  expect(store.count('User')).toEqual(2)
+  expect(store.count('Profile')).toEqual(2)
 
-  store.clear('User', 'Post', 'UserProfile')
+  store.clear('User', 'Post', 'Profile')
 
   expect(store.count('User')).toEqual(0)
   expect(store.count('Post')).toEqual(0)
-  expect(store.count('UserProfile')).toEqual(0)
+  expect(store.count('Profile')).toEqual(0)
 })

--- a/tests/count.test.ts
+++ b/tests/count.test.ts
@@ -1,7 +1,7 @@
 import { Store } from '../src'
 import { schema, TypesMap } from './fixtures'
 import { toCollection } from './utils'
-import { postFactory, userFactory } from './utils/factories'
+import { commentFactory, postFactory, userFactory } from './utils/factories'
 
 const store = new Store<TypesMap>({
   schema,
@@ -14,8 +14,11 @@ it('should return the count of stored documents for given type', () => {
   expect(store.count('Post')).toEqual(0)
 
   toCollection(() => store.add('User', userFactory()), 5)
-  toCollection(() => store.add('Post', postFactory()), 5)
-
   expect(store.count('User')).toEqual(5)
+
+  toCollection(() => store.add('Post', postFactory()), 5)
   expect(store.count('Post')).toEqual(5)
+
+  toCollection(() => store.add('Comment', commentFactory()), 5)
+  expect(store.count('Comment')).toEqual(5)
 })

--- a/tests/delete.test.ts
+++ b/tests/delete.test.ts
@@ -25,17 +25,19 @@ it('should delete single documents in a collection', () => {
 })
 
 it('should not affect other collections', () => {
-  toCollection(() => store.add('User', userFactory()), 5)
   toCollection(() => store.add('Post', postFactory()), 5)
+  toCollection(() => store.add('User', userFactory()), 5)
   const user = store.findFirstOrThrow('User')
 
-  expect(store.count('User')).toEqual(5)
   expect(store.count('Post')).toEqual(5)
+  expect(store.count('User')).toEqual(10)
+  expect(store.count('Profile')).toEqual(10)
 
   store.delete(user)
 
-  expect(store.count('User')).toEqual(4)
+  expect(store.count('User')).toEqual(9)
   expect(store.count('Post')).toEqual(5)
+  expect(store.count('Profile')).toEqual(10)
   expect(
     store.find('User', (data) => {
       return data.username.startsWith(user.username)

--- a/tests/fixtures/index.ts
+++ b/tests/fixtures/index.ts
@@ -1,12 +1,24 @@
-import { Post, User, UserProfile } from './schema.types'
+import type {
+  Post,
+  User,
+  Profile,
+  Comment,
+  Image,
+  Video,
+  Text,
+} from './schema.types'
 
 import schema from './schema.graphql'
 export { schema }
 
-export type { Post, User, UserProfile }
+export type { Post, User, Profile, Comment, Text, Image, Video }
 
 export interface TypesMap {
   User: User
   Post: Post
-  UserProfile: UserProfile
+  Profile: Profile
+  Comment: Comment
+  Text: Text
+  Image: Image
+  Video: Video
 }

--- a/tests/fixtures/schema.graphql
+++ b/tests/fixtures/schema.graphql
@@ -1,27 +1,129 @@
-type Post {
-  id: ID!
-  title: String!
-  body: String!
+scalar DateTime
+scalar Email
+scalar Void
+
+type PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: String
+  endCursor: String
 }
 
-type UserProfile {
-  fullName: String!
-  github: String
-  twitter: String
-  website: String
+type Post {
+  id: ID!
+  likes: Int!
+  author: User!
+  likedBy: UserConnection!
+  content: PostContent!
+  createdAt: DateTime!
+  comments(input: CommentInput): CommentConnection!
+}
+
+union PostContent = Text | Image | Video
+
+type PostConnection {
+  count: Int!
+  edges: [PostEdge!]!
+  pageInfo: PageInfo!
+}
+
+type PostEdge {
+  cursor: String!
+  node: Post!
+}
+
+type Comment {
+  id: ID!
+  text: String!
+  author: User!
+  createdAt: DateTime!
+}
+
+type CommentConnection {
+  count: Int!
+  edges: [CommentEdge!]!
+  pageInfo: PageInfo!
+}
+
+type CommentEdge {
+  cursor: String!
+  node: Comment!
+}
+
+type Text {
+  text: String!
+}
+
+type Image {
+  url: String!
+  caption: String
+  size: String!
+  width: Int!
+  height: Int!
+}
+
+type Video {
+  url: String!
+  caption: String
+  duration: Int!
+  mimeType: String!
+}
+
+type Profile {
+  username: String!
+  bio: String
+  avatar: Image
+  followers: UserConnection!
+  following: UserConnection!
+  posts: PostConnection!
+  joinedAt: DateTime!
 }
 
 type User {
   id: ID!
   username: String!
-  profile: UserProfile!
-  posts: [Post]!
+  email: Email!
+  profile: Profile!
+}
+
+type UserConnection {
+  count: Int!
+  edges: [UserEdge!]!
+  pageInfo: PageInfo!
+}
+
+type UserEdge {
+  cursor: String!
+  node: User!
+}
+
+input CommentInput {
+  pagination: PaginationInput
+  filter: CommentFilterInput
+}
+
+input CommentFilterInput {
+  author: String
+}
+
+input PaginationInput {
+  first: Int
+  last: Int
+  before: String
+  after: String
+}
+
+input CreateUserInput {
+  username: String!
+  email: Email!
+  password: String!
 }
 
 type Query {
-  user(id: ID!): User
+  profile(username: String!): Profile!
 }
 
 type Mutation {
-  createUser(id: ID!): User
+  createUser(input: CreateUserInput!): User!
+  deleteUser(id: ID!): Void!
 }

--- a/tests/reset.test.ts
+++ b/tests/reset.test.ts
@@ -1,6 +1,6 @@
 import { Store } from '../src'
 import { schema, TypesMap } from './fixtures'
-import { postFactory, userFactory } from './utils/factories'
+import { postFactory } from './utils/factories'
 import { toCollection } from './utils'
 
 const store = new Store<TypesMap>({

--- a/tests/reset.test.ts
+++ b/tests/reset.test.ts
@@ -10,14 +10,15 @@ const store = new Store<TypesMap>({
 afterEach(() => store.reset())
 
 it('should clear all collections at once', () => {
-  toCollection(() => store.add('User', userFactory()), 5)
   toCollection(() => store.add('Post', postFactory()), 5)
 
   expect(store.count('User')).toEqual(5)
   expect(store.count('Post')).toEqual(5)
+  expect(store.count('Profile')).toEqual(5)
 
   store.reset()
 
   expect(store.count('User')).toEqual(0)
   expect(store.count('Post')).toEqual(0)
+  expect(store.count('Profile')).toEqual(0)
 })

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -1,7 +1,7 @@
 import { randUserName } from '@ngneat/falso'
 import { Store } from '../src'
 import { schema, TypesMap } from './fixtures'
-import { userFactory, userProfileFactory } from './utils/factories'
+import { userFactory, profileFactory } from './utils/factories'
 import { Document } from '../src/types'
 import { User } from './fixtures'
 import { getDocumentKey, getDocumentType } from '../src/document'
@@ -38,7 +38,7 @@ it('can update document partially', () => {
 
   const data: Partial<User> = {
     username: randUserName(),
-    profile: userProfileFactory(),
+    profile: profileFactory(),
   }
 
   const updatedUser = store.update(user, data)

--- a/tests/utils/factories.ts
+++ b/tests/utils/factories.ts
@@ -1,18 +1,37 @@
-import { Post, User, UserProfile } from '../fixtures'
+import { Comment, Post, User, Profile, Image, Text, Video } from '../fixtures'
 import {
   randUuid,
   randText,
   randUserName,
-  randParagraph,
-  randFullName,
+  randEmail,
   randUrl,
+  randNumber,
+  rand,
 } from '@ngneat/falso'
 
 export function postFactory(overrides?: Partial<Post>): Post {
   return {
     id: randUuid(),
-    title: randText({ charCount: 40 }),
-    body: randParagraph(),
+    author: userFactory(),
+    comments: {
+      count: 0,
+      edges: [],
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false,
+      },
+    },
+    likes: 0,
+    likedBy: {
+      count: 0,
+      edges: [],
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false,
+      },
+    },
+    content: rand([imageFactory, videoFactory, textFactory])(),
+    createdAt: new Date().toISOString(),
     ...overrides,
   }
 }
@@ -21,20 +40,80 @@ export function userFactory(overrides?: Partial<User>): User {
   return {
     id: randUuid(),
     username: randUserName(),
-    profile: userProfileFactory(),
-    posts: [],
+    email: randEmail(),
+    profile: profileFactory(),
     ...overrides,
   }
 }
 
-export function userProfileFactory(
-  overrides?: Partial<UserProfile>,
-): UserProfile {
+export function profileFactory(overrides?: Partial<Profile>): Profile {
   return {
-    fullName: randFullName(),
-    github: randUserName(),
-    twitter: randUserName(),
-    website: randUrl(),
+    username: randUserName(),
+    bio: randText(),
+    avatar: imageFactory(),
+    followers: {
+      count: 0,
+      edges: [],
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false,
+      },
+    },
+    following: {
+      count: 0,
+      edges: [],
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false,
+      },
+    },
+    posts: {
+      count: 0,
+      edges: [],
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false,
+      },
+    },
+    joinedAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+export function commentFactory(overrides?: Partial<Comment>): Comment {
+  return {
+    id: randUuid(),
+    author: userFactory(),
+    text: randText(),
+    createdAt: new Date().toString(),
+    ...overrides,
+  }
+}
+
+function imageFactory(overrides?: Partial<Image>): Image {
+  return {
+    url: randUrl(),
+    caption: randText(),
+    height: randNumber({ min: 100, max: 1024 }),
+    width: randNumber({ min: 100, max: 1024 }),
+    size: `${randNumber({ min: 100, max: 1024 })}kb`,
+    ...overrides,
+  }
+}
+
+function videoFactory(overrides?: Partial<Video>): Video {
+  return {
+    url: randUrl(),
+    caption: randText(),
+    duration: randNumber({ min: 100, max: 10 }),
+    mimeType: rand(['video/mp4', 'video/avi', 'video/mkv', 'video/webm']),
+    ...overrides,
+  }
+}
+
+function textFactory(overrides?: Partial<Text>): Text {
+  return {
+    text: randText(),
     ...overrides,
   }
 }

--- a/tests/utils/index.ts
+++ b/tests/utils/index.ts
@@ -1,3 +1,9 @@
+import { PostContent, Text } from '../fixtures/schema.types'
+
 export function toCollection<T>(callback: () => T, times: number) {
   return Array.from({ length: times }, () => callback())
+}
+
+export function isTextContent(content: PostContent): content is Text {
+  return Reflect.has(content, 'text')
 }


### PR DESCRIPTION
To test various edge cases and stabilize the codebase, we need a more complex and real-world schema. So I've updated the schema and added more types with different relations. I've also used the connection pagginations to add intermediate types to the schema. Unfortunately, it makes the test much more lengthy and complicated, but it's necessary to make sure everything works fine with large graphql schemas. 